### PR TITLE
Throw error when provided invalid _since parameter

### DIFF
--- a/built/lib/utils.js
+++ b/built/lib/utils.js
@@ -235,6 +235,9 @@ function fhirInstant(input) {
         if (instant.isValid()) {
             return instant.format();
         }
+        else {
+            throw new Error(`Invalid fhirInstant: ${input}`);
+        }
     }
     return "";
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -268,6 +268,9 @@ export function fhirInstant(input: any): string
         if (instant.isValid()) {
             return instant.format();
         }
+        else {
+          throw new Error(`Invalid fhirInstant: ${input}`);
+        }
     }
     return "";
 }


### PR DESCRIPTION
# Summary

Addresses https://github.com/smart-on-fhir/bulk-data-client/issues/12

This PR changes how the client reacts to improperly formattted `_since` parameters. Previously, improperly formatted `_since` parameters were silently ignored. With this PR an error is thrown instead.

e.g.

```shell
> node . --_since 2010-03-14T09:00:00.000-4:00 -f htt://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir
Invalid fhirInstant: 2010-03-14T09:00:00.000-4:00
```