### PR TITLE
Reduce max status check from a day to a minute

### DIFF
--- a/built/lib/BulkDataClient.js
+++ b/built/lib/BulkDataClient.js
@@ -322,7 +322,7 @@ class BulkDataClient extends events_1.EventEmitter {
                             retryAfterMSec = Math.ceil(d.getTime() - now);
                         }
                     }
-                    const poolDelay = Math.min(Math.max(retryAfterMSec, 100), 1000 * 60 * 60 * 24);
+                    const poolDelay = Math.min(Math.max(retryAfterMSec, 100), 1000 * 60);
                     Object.assign(status, {
                         percentComplete: isNaN(progressPct) ? -1 : progressPct,
                         nextCheckAfter: poolDelay,

--- a/src/lib/BulkDataClient.ts
+++ b/src/lib/BulkDataClient.ts
@@ -480,7 +480,7 @@ class BulkDataClient extends EventEmitter
                         }
                     }
 
-                    const poolDelay = Math.min(Math.max(retryAfterMSec, 100), 1000*60*60*24)
+                    const poolDelay = Math.min(Math.max(retryAfterMSec, 100), 1000*60)
 
                     Object.assign(status, {
                         percentComplete: isNaN(progressPct) ? -1 : progressPct,


### PR DESCRIPTION
Cerner will give us retryAfter times of multiple hours, which is not always practical.

And since we are writing performance logs, we probably want to ensure that they are semi-accurate within some time frame (with this PR, to within a minute).