### PR TITLE
No longer zip old log files, it was buggy

### DIFF
--- a/built/loggers.js
+++ b/built/loggers.js
@@ -15,7 +15,6 @@ function createLogger(options = {}) {
         transports: [
             new winston_1.transports.File({
                 filename: (0, path_1.resolve)(__dirname, '../downloads/log.ndjson'),
-                zippedArchive: true,
                 maxFiles: 5,
                 maxsize: 1024 * 1024,
                 tailable: true,

--- a/built/loggers/index.js
+++ b/built/loggers/index.js
@@ -15,7 +15,6 @@ function createLogger(options = {}) {
         transports: [
             new winston_1.transports.File({
                 filename: options.file || (0, path_1.resolve)(__dirname, "../../downloads/log.ndjson"),
-                zippedArchive: true,
                 maxFiles: 5,
                 maxsize: 1024 * 1024 * 50,
                 tailable: true,

--- a/built/src/loggers/index.js
+++ b/built/src/loggers/index.js
@@ -16,7 +16,6 @@ function createLogger(options = {}) {
         transports: [
             new winston_1.transports.File({
                 filename: (0, path_1.resolve)(__dirname, "../../", options.file || 'downloads/log.ndjson'),
-                zippedArchive: true,
                 maxFiles: 5,
                 maxsize: 1024 * 1024,
                 tailable: true,

--- a/src/loggers/index.ts
+++ b/src/loggers/index.ts
@@ -13,7 +13,6 @@ export function createLogger(options: BulkDataClient.LoggingOptions = {}) {
         transports: [
             new transports.File({
                 filename     : options.file || resolve(__dirname, "../../downloads/log.ndjson"),
-                zippedArchive: true,
                 maxFiles     : 5,
                 maxsize      : 1024 * 1024 * 50,
                 tailable     : true,


### PR DESCRIPTION
- Files would not be zipped, only renamed with .gz
- They would sometimes have some binary garbage appended to them
- There are reports of this flag preventing file rotation completely when tailable=true in Winston 3.9.0 (we are still on 3.8.2)

Since we aren't getting the benefit of gzipped files, might as well avoid the downsides (binary garbage and tailable interactions) until these issues are fixed.

(See upstream Winston issues 1128 and 2318, not linked here just to avoid the auto-link-back that github aggressively inserts)