### PR TITLE
Make default max line length a little more generous

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -176,7 +176,7 @@
      * as JSON. It is recommended to set a reasonable limit for the line
      * length so that a huge line does not consume the entire memory.
      */
-    ndjsonMaxLineLength: 1000000,
+    ndjsonMaxLineLength: 10000000,
 
     /**
      * If `true`, verifies that every single JSON object extracted for the


### PR DESCRIPTION
We know that Ian was hitting the line length limit. And I just realized that we do at BCH too - I've been using this patch for a while now and had just forgotten about it.

So let's use a default with wider compatibility out of the box.