### PR TITLE
Feature #21: Response headers now indicated in relevant error events

### DIFF
--- a/built/app.js
+++ b/built/app.js
@@ -91,7 +91,7 @@ APP.action(async (args) => {
         const logger = (0, loggers_1.createLogger)(options.log);
         const startTime = Date.now();
         // kickoff -----------------------------------------------------------------
-        client.on("kickOffEnd", ({ requestParameters, capabilityStatement, response }) => {
+        client.on("kickOffEnd", ({ requestParameters, capabilityStatement, response, responseHeaders }) => {
             logger.log("info", {
                 eventId: "kickoff",
                 eventDetail: {
@@ -102,7 +102,8 @@ APP.action(async (args) => {
                     softwareVersion: capabilityStatement.software?.version || null,
                     softwareReleaseDate: capabilityStatement.software?.releaseDate || null,
                     fhirVersion: capabilityStatement.fhirVersion || null,
-                    requestParameters
+                    requestParameters,
+                    responseHeaders,
                 }
             });
         });

--- a/built/lib/FileDownload.js
+++ b/built/lib/FileDownload.js
@@ -78,6 +78,7 @@ class FileDownload extends events_1.default {
                     return reject(new errors_1.FileDownloadError({
                         fileUrl: this.url,
                         body: res.body,
+                        responseHeaders: res.headers,
                         code: res.statusCode
                     }));
                 }

--- a/built/lib/errors.js
+++ b/built/lib/errors.js
@@ -2,10 +2,11 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FileDownloadError = void 0;
 class FileDownloadError extends Error {
-    constructor({ body, code, fileUrl }) {
+    constructor({ body, code, responseHeaders, fileUrl }) {
         super(`Downloading the file from ${fileUrl} returned HTTP status code ${code}.${body ? " Body: " + JSON.stringify(body) : ""}`);
-        this.code = code;
         this.body = body;
+        this.responseHeaders = responseHeaders;
+        this.code = code;
         this.fileUrl = fileUrl;
         Error.captureStackTrace(this, this.constructor);
     }

--- a/built/lib/utils.js
+++ b/built/lib/utils.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createDecompressor = exports.exit = exports.ask = exports.generateProgress = exports.fhirInstant = exports.assert = exports.humanFileSize = exports.getAccessTokenExpiration = exports.print = exports.formatDuration = exports.wait = exports.detectTokenUrl = exports.getTokenEndpointFromCapabilityStatement = exports.getTokenEndpointFromWellKnownSmartConfig = exports.getCapabilityStatement = exports.getWellKnownSmartConfig = void 0;
+exports.filterResponseHeaders = exports.createDecompressor = exports.exit = exports.ask = exports.generateProgress = exports.fhirInstant = exports.assert = exports.humanFileSize = exports.getAccessTokenExpiration = exports.print = exports.formatDuration = exports.wait = exports.detectTokenUrl = exports.getTokenEndpointFromCapabilityStatement = exports.getTokenEndpointFromWellKnownSmartConfig = exports.getCapabilityStatement = exports.getWellKnownSmartConfig = void 0;
 require("colors");
 const jsonwebtoken_1 = __importDefault(require("jsonwebtoken"));
 const url_1 = require("url");
@@ -368,3 +368,23 @@ function createDecompressor(res) {
     }
 }
 exports.createDecompressor = createDecompressor;
+/**
+ * Filter a Headers object down to a selected series of headers
+ * @param headers The object of headers to filter
+ * @param selectedHeaders The headers that should remain post-filter
+ * @returns Types.ResponseHeaders | {}
+ */
+function filterResponseHeaders(headers, selectedHeaders) {
+    // In the event the headers is undefined or null, just return undefined
+    if (!headers)
+        return undefined;
+    // NOTE: If an empty array of headers is specified, return none of them
+    return Object
+        .entries(headers)
+        .reduce((headers, [key, value]) => {
+        if (!selectedHeaders.includes(key))
+            return headers;
+        return { ...headers, [key]: value };
+    }, {});
+}
+exports.filterResponseHeaders = filterResponseHeaders;

--- a/built/streams/DocumentReferenceHandler.js
+++ b/built/streams/DocumentReferenceHandler.js
@@ -48,7 +48,8 @@ class DocumentReferenceHandler extends stream_1.Transform {
             throw new errors_1.FileDownloadError({
                 fileUrl: attachment.url,
                 body: null,
-                code: res.statusCode
+                responseHeaders: res.headers,
+                code: res.statusCode,
             });
         }
         const contentType = res.headers["content-type"] || "";

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -290,5 +290,13 @@
      * If the server does not provide `Retry-after` header use this number of
      * milliseconds before checking the status again
      */
-    retryAfterMSec: 200
+    retryAfterMSec: 200,
+
+    /**
+     * ResponseHeaders to include in error logs for debugging purposes
+     * When 'all' is specified, all responseHeaders are returned
+     * Otherwise, return all responseHeaders found in the logs
+     * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
+    */
+    errorDebuggingHeaders: 'all',
 }

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -298,5 +298,5 @@
      * Otherwise, return all responseHeaders found in the logs
      * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
     */
-    errorDebuggingHeaders: 'all',
+    logResponseHeaders: 'all',
 }

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -293,10 +293,11 @@
     retryAfterMSec: 200,
 
     /**
-     * ResponseHeaders to include in error logs for debugging purposes
-     * When 'all' is specified, all responseHeaders are returned
-     * Otherwise, return all responseHeaders found in the logs
-     * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
+    * ResponseHeaders to include in error logs for debugging purposes
+    * When 'all' is specified, all responseHeaders are returned
+    * When 'none' is specified, no responseHeaders are returned
+    * Otherwise, log any responseHeaders matches against 1...* strings/regexp 
+    * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
     */
     logResponseHeaders: 'all',
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -224,7 +224,7 @@ export declare namespace BulkDataClient {
         * Otherwise, return all responseHeaders found in the logs
         * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
         */
-        errorDebuggingHeaders: string[] | 'all'
+        logResponseHeaders: string[] | 'all'
     }
 
     interface LoggingOptions
@@ -490,7 +490,7 @@ export declare namespace BulkDataClient {
         * Otherwise, return all responseHeaders found in the logs
         * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
         */
-        errorDebuggingHeaders: string[] | 'all'
+        logResponseHeaders: string[] | 'all'
     }
 
     interface JWK {

--- a/index.d.ts
+++ b/index.d.ts
@@ -217,6 +217,14 @@ export declare namespace BulkDataClient {
          * milliseconds before checking the status again
          */
         retryAfterMSec?: number
+
+        /**
+        * ResponseHeaders to include in error logs for debugging purposes
+        * When 'all' is specified, all responseHeaders are returned
+        * Otherwise, return all responseHeaders found in the logs
+        * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
+        */
+        errorDebuggingHeaders: string[] | 'all'
     }
 
     interface LoggingOptions
@@ -475,6 +483,14 @@ export declare namespace BulkDataClient {
          * milliseconds before checking the status again
          */
         retryAfterMSec: number
+
+        /**
+        * ResponseHeaders to include in error logs for debugging purposes
+        * When 'all' is specified, all responseHeaders are returned
+        * Otherwise, return all responseHeaders found in the logs
+        * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
+        */
+        errorDebuggingHeaders: string[] | 'all'
     }
 
     interface JWK {
@@ -723,6 +739,10 @@ export declare namespace BulkDataClient {
         virtual         ?: boolean
         statusEndpoint   : string
     }
+    
+    interface ResponseHeaders {
+        [key: string]: string | string[] | undefined
+    } 
 }
 
 export interface JsonObject { [key: string]: JsonValue; }

--- a/index.d.ts
+++ b/index.d.ts
@@ -224,7 +224,7 @@ export declare namespace BulkDataClient {
         * Otherwise, return all responseHeaders found in the logs
         * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
         */
-        logResponseHeaders: string[] | 'all'
+        logResponseHeaders: "all" | "none" | string | RegExp | (string | RegExp)[]
     }
 
     interface LoggingOptions
@@ -487,10 +487,11 @@ export declare namespace BulkDataClient {
         /**
         * ResponseHeaders to include in error logs for debugging purposes
         * When 'all' is specified, all responseHeaders are returned
-        * Otherwise, return all responseHeaders found in the logs
+        * When 'none' is specified, no responseHeaders are returned
+        * Otherwise, log any responseHeaders matches against 1...* strings/regexp 
         * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
         */
-        logResponseHeaders: string[] | 'all'
+        logResponseHeaders: "all" | "none" | string | RegExp | (string | RegExp)[]
     }
 
     interface JWK {

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,7 +221,8 @@ export declare namespace BulkDataClient {
         /**
         * ResponseHeaders to include in error logs for debugging purposes
         * When 'all' is specified, all responseHeaders are returned
-        * Otherwise, return all responseHeaders found in the logs
+        * When 'none' is specified, no responseHeaders are returned
+        * Otherwise, log any responseHeaders matches against 1...* strings/regexp 
         * NOTE: When an empty array is specified, an empty object of responseHeaders will be returned
         */
         logResponseHeaders: "all" | "none" | string | RegExp | (string | RegExp)[]

--- a/src/app.ts
+++ b/src/app.ts
@@ -110,7 +110,7 @@ APP.action(async (args: BulkDataClient.CLIOptions) => {
         const startTime = Date.now()
 
         // kickoff -----------------------------------------------------------------
-        client.on("kickOffEnd", ({ requestParameters, capabilityStatement, response }) => {
+        client.on("kickOffEnd", ({ requestParameters, capabilityStatement, response, responseHeaders }) => {
             logger.log("info", {
                 eventId: "kickoff",
                 eventDetail: {
@@ -121,7 +121,8 @@ APP.action(async (args: BulkDataClient.CLIOptions) => {
                     softwareVersion    : capabilityStatement.software?.version           || null,
                     softwareReleaseDate: capabilityStatement.software?.releaseDate       || null,
                     fhirVersion        : capabilityStatement.fhirVersion                 || null,
-                    requestParameters
+                    requestParameters, 
+                    responseHeaders,
                 }
             })
         })

--- a/src/lib/BulkDataClient.ts
+++ b/src/lib/BulkDataClient.ts
@@ -267,14 +267,14 @@ class BulkDataClient extends EventEmitter
 
     /**
      * Internal method for formatting response headers for some emitted events 
-     * based on `options.errorDebuggingHeaders`
+     * based on `options.logResponseHeaders`
      * @param headers 
      * @returns responseHeaders
      */
     private formatResponseHeaders(headers: Types.ResponseHeaders) : Types.ResponseHeaders | undefined { 
-        return (this.options.errorDebuggingHeaders === 'all' 
+        return (this.options.logResponseHeaders === 'all' 
             ?  headers
-            :  filterResponseHeaders(headers, this.options.errorDebuggingHeaders)
+            :  filterResponseHeaders(headers, this.options.logResponseHeaders)
         )
     }
 

--- a/src/lib/BulkDataClient.ts
+++ b/src/lib/BulkDataClient.ts
@@ -271,11 +271,15 @@ class BulkDataClient extends EventEmitter
      * @param headers 
      * @returns responseHeaders
      */
-    private formatResponseHeaders(headers: Types.ResponseHeaders) : Types.ResponseHeaders | undefined { 
-        return (this.options.logResponseHeaders === 'all' 
-            ?  headers
-            :  filterResponseHeaders(headers, this.options.logResponseHeaders)
-        )
+    private formatResponseHeaders(headers: Types.ResponseHeaders) : Types.ResponseHeaders | undefined {
+        if (this.options.logResponseHeaders.toString().toLocaleLowerCase() === 'none') return undefined
+        if (this.options.logResponseHeaders.toString().toLocaleLowerCase() === 'all') return headers
+        // If not an array it must be a string or a RegExp 
+        if (!Array.isArray(this.options.logResponseHeaders)) {
+            return filterResponseHeaders(headers, [this.options.logResponseHeaders])
+        } 
+        // Else it must be an array
+        return filterResponseHeaders(headers, this.options.logResponseHeaders)
     }
 
     /**

--- a/src/lib/BulkDataClient.ts
+++ b/src/lib/BulkDataClient.ts
@@ -55,10 +55,10 @@ export interface BulkDataClientEvents {
      * @event
      */
     "kickOffEnd": (this: BulkDataClient, data: {
-        response           : Response
-        capabilityStatement: fhir4.CapabilityStatement
-        requestParameters  : Record<string, any>
-        responseHeaders    : Types.ResponseHeaders | undefined
+        response            : Response
+        capabilityStatement : fhir4.CapabilityStatement
+        requestParameters   : Record<string, any>
+        responseHeaders    ?: Types.ResponseHeaders
     }) => void;
     
     /**
@@ -77,7 +77,7 @@ export interface BulkDataClientEvents {
         body             : string | fhir4.OperationOutcome | null
         code             : number | null
         message         ?: string
-        responseHeaders  : Types.ResponseHeaders | undefined
+        responseHeaders ?: Types.ResponseHeaders 
     }) => void;
     
     /**
@@ -111,7 +111,7 @@ export interface BulkDataClientEvents {
         code             : number | null
         fileUrl          : string
         message         ?: string
-        responseHeaders  : Types.ResponseHeaders | undefined
+        responseHeaders ?: Types.ResponseHeaders
     }) => void;
 
     /**

--- a/src/lib/FileDownload.ts
+++ b/src/lib/FileDownload.ts
@@ -130,9 +130,10 @@ class FileDownload extends EventEmitter
                 // In case we get an error response ----------------------------
                 if (res.statusCode >= 400) {
                     return reject(new FileDownloadError({
-                        fileUrl: this.url,
-                        body: res.body,
-                        code: res.statusCode
+                        fileUrl         : this.url,
+                        body            : res.body,
+                        responseHeaders : res.headers,
+                        code            : res.statusCode
                     }))
                 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,27 +1,32 @@
+import { BulkDataClient as Types } from "../..";
 
 export class FileDownloadError extends Error
 {
     readonly code: number;
     readonly body: string | object | null;
+    readonly responseHeaders: Types.ResponseHeaders
     readonly fileUrl: string
 
     constructor({
         body,
         code,
+        responseHeaders,
         fileUrl
     }: {
-        body: string | fhir4.OperationOutcome | null, // Buffer
-        code: number,
-        fileUrl: string
+        body            : string | fhir4.OperationOutcome | null, // Buffer
+        responseHeaders : Types.ResponseHeaders,
+        code            : number,
+        fileUrl         : string
     }) {
         super(`Downloading the file from ${fileUrl
             } returned HTTP status code ${code}.${
             body ? " Body: " + JSON.stringify(body) : ""
         }`)
 
-        this.code = code
-        this.body = body
-        this.fileUrl = fileUrl
+        this.body            = body
+        this.responseHeaders = responseHeaders
+        this.code            = code
+        this.fileUrl         = fileUrl
 
         Error.captureStackTrace(this, this.constructor)
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -437,9 +437,11 @@ export function filterResponseHeaders(headers: Types.ResponseHeaders, selectedHe
     return Object
         .entries(headers)
         .reduce((matchedHeaders, [key, value]) => {
+            // These are usually normalized to lowercase by most libraries, but just to be sure
+            const lowercaseKey = key.toLocaleLowerCase()
             // Each selectedHeader is either a RegExp, where we check for matches via RegExp.test
             // or a string, where we check for matches with equality
-            if (selectedHeaders.find((h) => isRegExp(h) ? h.test(key) : h === key)) return { ...matchedHeaders, [key] : value}
+            if (selectedHeaders.find((h) => isRegExp(h) ? h.test(lowercaseKey) : h.toLocaleLowerCase() === lowercaseKey)) return { ...matchedHeaders, [key] : value}
             // If we don't find a selectedHeader that matches this header, we move on
             return matchedHeaders
         }, {})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,7 +8,7 @@ import { HTTPError, Response }        from "got/dist/source"
 import zlib                           from "zlib"
 import request                        from "./request"
 import { Transform }                  from "stream"
-import { BulkDataClient, JsonObject } from "../.."
+import { BulkDataClient as Types, JsonObject } from "../.."
 
 
 const debug = util.debuglog("app")
@@ -208,7 +208,7 @@ export const print = (() => {
  * Note that this should only be used immediately after an access token is
  * received, otherwise the computed timestamp will be incorrect.
  */
-export function getAccessTokenExpiration(tokenResponse: BulkDataClient.TokenResponse): number
+export function getAccessTokenExpiration(tokenResponse: Types.TokenResponse): number
 {
     const now = Math.floor(Date.now() / 1000);
 
@@ -421,4 +421,22 @@ export function createDecompressor(res: Response): Transform
             }
         })
     }
+}
+
+/**
+ * Filter a Headers object down to a selected series of headers
+ * @param headers The object of headers to filter
+ * @param selectedHeaders The headers that should remain post-filter
+ * @returns Types.ResponseHeaders | {}
+ */
+export function filterResponseHeaders(headers: Types.ResponseHeaders, selectedHeaders: string[]) : Types.ResponseHeaders | {} | undefined { 
+    // In the event the headers is undefined or null, just return undefined
+    if (!headers) return undefined
+    // NOTE: If an empty array of headers is specified, return none of them
+    return Object
+        .entries(headers)
+        .reduce((headers, [key, value]) => {
+            if (!selectedHeaders.includes(key)) return headers
+            return {...headers, [key]: value}
+        }, {})
 }

--- a/src/streams/DocumentReferenceHandler.ts
+++ b/src/streams/DocumentReferenceHandler.ts
@@ -65,9 +65,10 @@ export default class DocumentReferenceHandler extends Transform
 
         if (res.statusCode >= 400) {
             throw new FileDownloadError({
-                fileUrl: attachment.url,
-                body   : null,
-                code   : res.statusCode
+                fileUrl         : attachment.url,
+                body            : null,
+                responseHeaders : res.headers,
+                code            : res.statusCode,
             });
         }
 

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -43,7 +43,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 404, body: "", headers: { "content-location": "x"}});
 
-            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
+            const { log } = await invoke({options: {logResponseHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -77,7 +77,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200, body: "" });
 
-            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
+            const { log } = await invoke({options: {logResponseHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -101,7 +101,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200, body: "" });
 
-            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
+            const { log } = await invoke({options: {logResponseHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -135,7 +135,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200 });
 
-            const { log } = await invoke({ args: ["--_since", "2020" ], options: {errorDebuggingHeaders: []}})
+            const { log } = await invoke({ args: ["--_since", "2020" ], options: {logResponseHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             expect(entry, "kickoff log entry not found").to.exist()
@@ -169,7 +169,7 @@ describe('Logging', function () {
                 body: ""
             });
 
-            const { log } = await invoke({ options: { errorDebuggingHeaders: 'all'} })
+            const { log } = await invoke({ options: { logResponseHeaders: 'all'} })
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             expect(entry, "kickoff log entry not found").to.exist()
@@ -178,7 +178,7 @@ describe('Logging', function () {
             expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
         })
 
-        it ("can filter responseHeaders of kickoff events with client's errorDebuggingHeaders option", async () => {
+        it ("can filter responseHeaders of kickoff events with client's logResponseHeaders option", async () => {
             mockServer.mock("/metadata", {
                 status: 200,
                 body: {
@@ -200,7 +200,7 @@ describe('Logging', function () {
                 body: ""
             });
 
-            const { log } = await invoke({ options: { errorDebuggingHeaders: ['x-debugging-header', 'content-location']} })
+            const { log } = await invoke({ options: { logResponseHeaders: ['x-debugging-header', 'content-location']} })
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             expect(entry, "kickoff log entry not found").to.exist()
@@ -281,7 +281,7 @@ describe('Logging', function () {
             expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
         })
 
-        it ("can filter responseHeaders of status_error events with client's errorDebuggingHeaders option", async () => {
+        it ("can filter responseHeaders of status_error events with client's logResponseHeaders option", async () => {
             this.timeout(10000);
 
             mockServer.mock("/metadata", { status: 200, body: {} });
@@ -300,7 +300,7 @@ describe('Logging', function () {
                 headers: {"x-debugging-header": "someValue"}
             })
 
-            const { log } = await invoke({options: { errorDebuggingHeaders: ['x-debugging-header']}})
+            const { log } = await invoke({options: { logResponseHeaders: ['x-debugging-header']}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "status_error")
             expect(entry).to.exist()

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -43,7 +43,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 404, body: "", headers: { "content-location": "x"}});
 
-            const { log } = await invoke()
+            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -56,7 +56,8 @@ describe('Logging', function () {
                 "softwareVersion": "Software Version",
                 "softwareReleaseDate": "01-02-03",
                 "fhirVersion": 100,
-                "requestParameters": {}
+                "requestParameters": {},
+                "responseHeaders": {}
             })
         })
 
@@ -76,7 +77,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200, body: "" });
 
-            const { log } = await invoke()
+            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -89,7 +90,8 @@ describe('Logging', function () {
                 "softwareVersion": "Software Version",
                 "softwareReleaseDate": "01-02-03",
                 "fhirVersion": 100,
-                "requestParameters": {}
+                "requestParameters": {},
+                "responseHeaders": {},
             })
         })
 
@@ -99,7 +101,7 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200, body: "" });
 
-            const { log } = await invoke()
+            const { log } = await invoke({options: {errorDebuggingHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
             
@@ -112,7 +114,8 @@ describe('Logging', function () {
                 "softwareVersion": null,
                 "softwareReleaseDate": null,
                 "fhirVersion": null,
-                "requestParameters": {}
+                "requestParameters": {},
+                "responseHeaders": {}
             })
         })
 
@@ -132,10 +135,9 @@ describe('Logging', function () {
 
             mockServer.mock("/Patient/$export", { status: 200 });
 
-            const { log } = await invoke({ args: ["--_since", "2020" ]})
+            const { log } = await invoke({ args: ["--_since", "2020" ], options: {errorDebuggingHeaders: []}})
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "kickoff")
-            
             expect(entry, "kickoff log entry not found").to.exist()
             expect(entry.eventDetail).to.be.an.object()
             expect(entry.eventDetail.exportUrl).to.be.a.string()
@@ -144,7 +146,73 @@ describe('Logging', function () {
             expect(entry.eventDetail.requestParameters).to.be.an.object()
             expect(entry.eventDetail.requestParameters._since).to.exist()
         })
+
+        it ("includes responseHeaders in kickoff log entries", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03"
+                    }
+                }
+            });
+            // NOTE: Request endpoint is invalid without the "\\"
+            mockServer.mock("/Patient/\\$export", {
+                status: 200,
+                headers: {
+                    "content-location": mockServer.baseUrl + "/status",
+                    "x-debugging-header": "someValue",
+                },
+                body: ""
+            });
+
+            const { log } = await invoke({ options: { errorDebuggingHeaders: 'all'} })
+            const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
+            const entry = logs.find(l => l.eventId === "kickoff")
+            expect(entry, "kickoff log entry not found").to.exist()
+            expect(entry.eventDetail).to.be.an.object()
+            expect(entry.eventDetail.responseHeaders).to.be.an.object()
+            expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
+        })
+
+        it ("can filter responseHeaders of kickoff events with client's errorDebuggingHeaders option", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03"
+                    }
+                }
+            });
+            // NOTE: Request endpoint is invalid without the "\\"
+            mockServer.mock("/Patient/\\$export", {
+                status: 200,
+                headers: {
+                    "content-location": mockServer.baseUrl + "/status",
+                    "x-debugging-header": "someValue",
+                },
+                body: ""
+            });
+
+            const { log } = await invoke({ options: { errorDebuggingHeaders: ['x-debugging-header', 'content-location']} })
+            const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
+            const entry = logs.find(l => l.eventId === "kickoff")
+            expect(entry, "kickoff log entry not found").to.exist()
+            expect(entry.eventDetail).to.be.an.object()
+            expect(entry.eventDetail.responseHeaders).to.be.an.object()
+            expect(entry.eventDetail.responseHeaders).to.equal({
+                "content-location": mockServer.baseUrl + "/status",
+                "x-debugging-header": "someValue",
+            })
+        })
     })
+
 
     describe('status events', () => {
 
@@ -197,7 +265,11 @@ describe('Logging', function () {
                 body: ""
             });
 
-            mockServer.mock("/status", { status: 404, body: "Status endpoint not found" })
+            mockServer.mock("/status", { 
+                status: 404, 
+                body: "Status endpoint not found", 
+                headers: {"x-debugging-header": "someValue"} 
+            })
 
             const { log } = await invoke()
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
@@ -205,6 +277,37 @@ describe('Logging', function () {
             expect(entry).to.exist()
             expect(entry.eventDetail.code).to.equal(404)
             expect(entry.eventDetail.body).to.equal("Status endpoint not found")
+            // Check response headers of status_error events
+            expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
+        })
+
+        it ("can filter responseHeaders of status_error events with client's errorDebuggingHeaders option", async () => {
+            this.timeout(10000);
+
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock("/Patient/\\$export", {
+                status: 200,
+                headers: {
+                    "content-location": mockServer.baseUrl + "/status"
+                },
+                body: ""
+            });
+
+            mockServer.mock("/status", { 
+                status: 404, 
+                body: "Status endpoint not found", 
+                headers: {"x-debugging-header": "someValue"}
+            })
+
+            const { log } = await invoke({options: { errorDebuggingHeaders: ['x-debugging-header']}})
+            const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
+            const entry = logs.find(l => l.eventId === "status_error")
+            expect(entry).to.exist()
+            expect(entry.eventDetail.code).to.equal(404)
+            expect(entry.eventDetail.body).to.equal("Status endpoint not found")
+            // Check response headers of status_error events
+            expect(entry.eventDetail.responseHeaders).to.equal({"x-debugging-header": "someValue"})
         })
 
         it ("logs status_complete events", async () => {
@@ -493,8 +596,15 @@ describe('Logging', function () {
                     url : mockServer.baseUrl + "/downloads/file1.json",
                     type: "Patient"
                 }],
-                error: []
+                error: [],
             }})
+
+            // Simulate 404 for downloads/file1.json with some response headers
+            mockServer.mock("/downloads/file1.json", { 
+                status: 404, 
+                body: '',
+                headers: {"x-debugging-header": "someValue"}
+            })
 
             const { log } = await invoke()
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
@@ -506,6 +616,8 @@ describe('Logging', function () {
             expect(entry.eventDetail.message).to.equal(
                 `Downloading the file from ${mockServer.baseUrl}/downloads/file1.json returned HTTP status code 404.`
             )
+            expect(entry.eventDetail.responseHeaders).to.be.object()
+            expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
         })
 
         it ("logs download_error events on invalid file contents", async () => {
@@ -539,7 +651,6 @@ describe('Logging', function () {
             const { log } = await invoke()
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "download_error")
-
             expect(entry).to.exist()
             expect(entry.eventDetail.fileUrl).to.equal(mockServer.baseUrl + "/downloads/file1")
             expect(entry.eventDetail.body).to.equal(null)
@@ -581,7 +692,6 @@ describe('Logging', function () {
             const { log } = await invoke()
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
             const entry = logs.find(l => l.eventId === "download_error")
-
             expect(entry).to.exist()
             expect(entry.eventDetail.fileUrl).to.equal(mockServer.baseUrl + "/downloads/file1")
             expect(entry.eventDetail.body).to.equal(null)
@@ -628,19 +738,18 @@ describe('Logging', function () {
                 }
             })
 
-            mockServer.mock("/document.pdf", { status: 500 })
+            mockServer.mock("/document.pdf", { status: 500, headers: {'x-debugging-header': "someValue"} })
 
             const { log } = await invoke()
             const logs = log.split("\n").filter(Boolean).map(line => JSON.parse(line));
-            // console.log(logs)
             const entry = logs.find(l => l.eventId === "download_error")
-
             expect(entry).to.exist()
             expect(entry.eventDetail.fileUrl).to.equal(mockServer.baseUrl + "/document.pdf")
             expect(entry.eventDetail.body).to.equal(null)
             expect(entry.eventDetail.message).to.equal(
                 `Downloading the file from ${mockServer.baseUrl}/document.pdf returned HTTP status code 500.`
             )
+            expect(entry.eventDetail.responseHeaders).to.include({"x-debugging-header": "someValue"})
         })  
     })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,16 +14,7 @@ describe('Utils Library', function () {
         'header': 'value',
         'header2': 'value2',
       }
-      expect(filterResponseHeaders(headers, [] as string[])).to.equal({})
-    })
-    it ("returns an object containing the headers in selectedHeaders", () => { 
-      const headers = {
-        'header': 'value',
-        'header2': 'value2',
-      }
-      expect(filterResponseHeaders(headers, ['header'])).to.equal({'header': 'value'})
-      expect(filterResponseHeaders(headers, ['header2'])).to.equal({'header2': 'value2'})
-      expect(filterResponseHeaders(headers, ['header', 'header2'])).to.equal(headers)
+      expect(filterResponseHeaders(headers, [])).to.equal({})
     })
     it ("returns an empty object if selectedHeaders's headers are not found", () => { 
       const headers = {
@@ -32,5 +23,42 @@ describe('Utils Library', function () {
       }
       expect(filterResponseHeaders(headers, ['header3'])).to.equal({})
     })
+    it ("finds matching headers given strings in selectedHeaders", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+      }
+      expect(filterResponseHeaders(headers, ['header'])).to.equal({'header': 'value'})
+      expect(filterResponseHeaders(headers, ['header2'])).to.equal({'header2': 'value2'})
+      // Handles multiple options well
+      expect(filterResponseHeaders(headers, ['header', 'header2'])).to.equal(headers)
+    })
+    it ("finds matching headers given regexps in selectedHeaders", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+      }
+      expect(filterResponseHeaders(headers, [new RegExp('header.*')])).to.equal(headers)
+      // NOTE: Partial match is still a match against both keys
+      expect(filterResponseHeaders(headers, [/header/])).to.equal(headers)
+      expect(filterResponseHeaders(headers, [new RegExp('header')])).to.equal(headers)
+      // Expecting an additional character, only matches our second header
+      expect(filterResponseHeaders(headers, [new RegExp('header.+')])).to.equal({'header2': 'value2'})
+      // Handles multiple regexp fine
+      expect(filterResponseHeaders(headers, [new RegExp('header2'), new RegExp('header$')])).to.equal(headers)
+      // Correctly handles cases of no matching
+      expect(filterResponseHeaders(headers, [new RegExp('footer.+')])).to.equal({})
+    })
+    it ("finds matching headers if selectedHeaders contains a mix of strings and RegExp ", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+        'new': 'string',
+        'footer': 'random',
+      }
+      expect(filterResponseHeaders(headers, ['new', new RegExp('header'), new RegExp('foot.*')])).to.equal(headers)
+      expect(filterResponseHeaders(headers, ['newish', new RegExp('footer.+')])).to.equal({})
+    })
+
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -59,6 +59,17 @@ describe('Utils Library', function () {
       expect(filterResponseHeaders(headers, ['new', new RegExp('header'), new RegExp('foot.*')])).to.equal(headers)
       expect(filterResponseHeaders(headers, ['newish', new RegExp('footer.+')])).to.equal({})
     })
-
+    it ("uses case-insensitive checks for string matching", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+        'NEW': 'string',
+        'footer': 'random',
+      }
+      // SelectedHeader is case-insensitive
+      expect(filterResponseHeaders(headers, ['HEADER'])).to.equal({'header': 'value'})
+      // source responseHeader is also case-insensitive in check; preserves case in result
+      expect(filterResponseHeaders(headers, ['new'])).to.equal({'NEW': 'string'})
+    })
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,36 @@
+import { expect }                 from "@hapi/code"
+import { filterResponseHeaders }  from "../src/lib/utils"
+
+describe('Utils Library', function () { 
+  describe('filterExportHeaders', () => { 
+    it ("returns undefined if headers is undefined or null", () => { 
+      // @ts-ignore
+      expect(filterResponseHeaders(undefined)).to.equal(undefined)
+      // @ts-ignore
+      expect(filterResponseHeaders(null)).to.equal(undefined)
+    })
+    it ("returns an empty object if selectedHeaders is an empty array", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+      }
+      expect(filterResponseHeaders(headers, [] as string[])).to.equal({})
+    })
+    it ("returns an object containing the headers in selectedHeaders", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+      }
+      expect(filterResponseHeaders(headers, ['header'])).to.equal({'header': 'value'})
+      expect(filterResponseHeaders(headers, ['header2'])).to.equal({'header2': 'value2'})
+      expect(filterResponseHeaders(headers, ['header', 'header2'])).to.equal(headers)
+    })
+    it ("returns an empty object if selectedHeaders's headers are not found", () => { 
+      const headers = {
+        'header': 'value',
+        'header2': 'value2',
+      }
+      expect(filterResponseHeaders(headers, ['header3'])).to.equal({})
+    })
+  })
+})


### PR DESCRIPTION
Addresses #21: Aligning with updates to the [wiki's logging-event specification](https://github.com/smart-on-fhir/bulk-data-client/wiki/Bulk-Data-Export-Log-Items), the bulk-data-client now includes responseHeaders in emitted error events – specifically  `kickOffEnd`, `exportError`, and `downloadError` – and, in `app.ts`'s eventlisteners, adds responseHeaders to the relevant logging events – specifically `kickoff`, `status_error` and `download_error` respectively. Note: since status_error and download_error are built from `eventDetail` directly, no change was needed after adding the information to exportError and downloadError's emitted eventDetails 

Which headers are output is configurable at the level of the BulkDataClient's config files, using the new `errorDebuggingHeaders` parameter. (open to notes on this naming decision, names are always hard). This parameter accepts two kinds of values – a list of headers to filter down to in the list of responseHeaders, and the keyword `all` which, as you'd expect, includes all responseHeaders in the logs (this is the default value).  

Relevant tests in `logging.test.ts` were updated to reflect these new fields in some events, and a new test file – `utils.test.ts` – is added to test the newly creted filterResponseHeaders method. 

@mikix let me know if this branch works to expose the relevant Cerner debugging headers discussed in #21 , and if there are UX-feedback items you have for me, as the person who raised this issue initially.

@vlad-ignatov let me know what you think of these changes. Note that I discussed the logging-event specification changes with Dan before pushing them, and he's given me a thumbs up 👍 .  Also, since this is my first PR to this repo, let me know if I'm missing anything you'd like to see before reviewing/approving 😄 