### PR TITLE
Adds the EAGAIN error code to the default list of error codes that should trigger a retry

### DIFF
--- a/built/lib/request.js
+++ b/built/lib/request.js
@@ -12,6 +12,19 @@ const package_json_1 = __importDefault(require("../../package.json"));
 require("colors");
 const debug = util_1.default.debuglog("app-request");
 exports.default = source_1.default.extend({
+    retry: {
+        errorCodes: [
+            'ETIMEDOUT',
+            'ECONNRESET',
+            'EADDRINUSE',
+            'ECONNREFUSED',
+            'EPIPE',
+            'ENOTFOUND',
+            'ENETUNREACH',
+            'EAI_AGAIN',
+            'EAGAIN'
+        ],
+    },
     hooks: {
         beforeRequest: [
             options => {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -11,6 +11,19 @@ const debug = util.debuglog("app-request")
 
 
 export default got.extend({
+    retry: {
+        errorCodes: [
+            'ETIMEDOUT',
+            'ECONNRESET',
+            'EADDRINUSE',
+            'ECONNREFUSED',
+            'EPIPE',
+            'ENOTFOUND',
+            'ENETUNREACH',
+            'EAI_AGAIN',
+            'EAGAIN'
+        ],
+    },
     hooks: {
         beforeRequest: [
             options => {
@@ -19,7 +32,6 @@ export default got.extend({
         ],        
         afterResponse: [
             (response, retryWithMergedOptions) => {
-
                 const { options } = response.request;
 
                 const payload = options.body || options.form || options.json


### PR DESCRIPTION
Does what it says on the box. Modifies the default `request` configuration, so this should work anywhere it is used.

Merging this will close #24. 