### PR TITLE
Update default scopes to SMART v2 syntax

### DIFF
--- a/built/lib/BulkDataClient.js
+++ b/built/lib/BulkDataClient.js
@@ -197,7 +197,7 @@ class BulkDataClient extends events_1.EventEmitter {
             method: "POST",
             responseType: "json",
             form: {
-                scope: this.options.scope || "system/*.read",
+                scope: this.options.scope || "system/*.rs",
                 grant_type: "client_credentials",
                 client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 client_assertion: token

--- a/built/src/lib/BulkDataClient.js
+++ b/built/src/lib/BulkDataClient.js
@@ -159,7 +159,7 @@ class BulkDataClient extends events_1.EventEmitter {
             method: "POST",
             responseType: "json",
             form: {
-                scope: this.options.scope || "system/*.read",
+                scope: this.options.scope || "system/*.rs",
                 grant_type: "client_credentials",
                 client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 client_assertion: token

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -34,9 +34,9 @@
 
     /**
      * The scope to use in the authorization request. If not set, defaults to
-     * "system/*.read"
+     * "system/*.rs"
      */
-    scope: "system/*.read",
+    scope: "system/*.rs",
 
     /**
      * The access token lifetime in seconds. Note that the authentication server

--- a/src/lib/BulkDataClient.ts
+++ b/src/lib/BulkDataClient.ts
@@ -344,7 +344,7 @@ class BulkDataClient extends EventEmitter
             method: "POST",
             responseType: "json",
             form: {
-                scope: this.options.scope || "system/*.read",
+                scope: this.options.scope || "system/*.rs",
                 grant_type: "client_credentials",
                 client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 client_assertion: token


### PR DESCRIPTION
In looking at the bulk data client during the Connectathon, I saw that the SMART bulk-data-client defaults to the old v1 scope syntax. It's small, but I think updating the default scopes to v2 makes sense, given that both Bulk v2.0 and SMART v2.0 have been released for over 3 years, and there has been substantial adoption of granular scopes. It appears that of the servers supporting SMART scopes at all for bulk, the vast majority would continue to work with no difference with this update. Conversely, it is unlikely that newly-developed bulk servers would support the v1 syntax since the conformance level for v1 scopes is only "SHOULD."